### PR TITLE
Update evaluate_detection_json_ek100.py

### DIFF
--- a/EvaluationCode/evaluate_detection_json_ek100.py
+++ b/EvaluationCode/evaluate_detection_json_ek100.py
@@ -93,6 +93,9 @@ class ANETdetection(object):
         # Import ground truth and predictions.
         self.ground_truth = load_gt_segmentations(annotations, label=label, num_nouns=num_nouns)
         self.prediction = load_predicted_segmentations(submission, label=label, num_nouns=num_nouns)
+                     
+        # Remove predictions of non-existing labels, this prevents double mapping of labels not in the ground truth
+        self.prediction = self.prediction[self.prediction['label'].isin(self.ground_truth['label'].unique())]
 
         self.activity_index = {j: i for i, j in enumerate(sorted(self.ground_truth['label'].unique()))}
 


### PR DESCRIPTION
Added code for removing predictions of labels not in the ground truth. This stops predictions not in the ground truth double mapping to labels within the activity index, causing proposals for different classes to be incorrectly considered to mapped classes.